### PR TITLE
pre styles to none

### DIFF
--- a/doteki/plugins/figlet.py
+++ b/doteki/plugins/figlet.py
@@ -10,7 +10,7 @@ def run(settings: dict[str, Any]) -> str | None:
     text = settings.get("ascii_text")
     font = settings.get("font", "standard")
     result = pyfiglet.figlet_format(text, font)
-    result = "<pre>" + result + "</pre>"
+    result = "<pre style='background: none; border: none'>" + result + "</pre>"
     return str(result)
 
 

--- a/tests/plugins/test_figlet.py
+++ b/tests/plugins/test_figlet.py
@@ -5,7 +5,7 @@ from doteki.plugins.figlet import run
 def test_prototype():
     settings = {"ascii_text": "hola"} 
     expected = """ _           _       \n| |__   ___ | | __ _ \n| '_ \\ / _ \\| |/ _` |\n| | | | (_) | | (_| |\n|_| |_|\\___/|_|\\__,_|\n                     \n"""
-    expected = "<pre>" + expected + "</pre>"
+    expected = "<pre style='background: none; border: none'>" + expected + "</pre>"
     result = run(settings)
     expected = expected.replace(" ", "S").replace("\n","r")
     result = result.replace(" ", "S").replace("\n","r")


### PR DESCRIPTION
## Summary

Just changed &lt;pre> styles to None for seamessly integration with default style of Readme.md
Modify one test affected

### Related issue

<!-- Mention any relevant issues like #123 -->

---

### How has this been tested?

- [X] Manual tests
- [X] Unit tests
- [ ] Integration tests

---

### Type of change

<!-- Mark the relevant option with an `x` like so: `[x]` (no spaces) -->

- [X] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [X] I have read the [**contributing guidelines**](https://github.com/welpo/doteki/blob/main/CONTRIBUTING.md).
- [ ] I have formatted the code with [Black](https://github.com/psf/black).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
